### PR TITLE
[JNI] zeKernelSetCacheConfig supported

### DIFF
--- a/levelZeroLib/src/levelZeroKernel.cpp
+++ b/levelZeroLib/src/levelZeroKernel.cpp
@@ -83,3 +83,16 @@ JNIEXPORT jint JNICALL Java_uk_ac_manchester_tornado_drivers_spirv_levelzero_Lev
     LOG_ZE_JNI("zeKernelSetArgumentValue [PTR]", result);
     return result;
 }
+
+/*
+ * Class:     uk_ac_manchester_tornado_drivers_spirv_levelzero_LevelZeroKernel
+ * Method:    zeKernelSetCacheConfig_native
+ * Signature: (JI)I
+ */
+JNIEXPORT jint JNICALL Java_uk_ac_manchester_tornado_drivers_spirv_levelzero_LevelZeroKernel_zeKernelSetCacheConfig_1native
+    (JNIEnv *, jobject, jlong javaKernelHandlerPtr, jint flag) {
+    ze_kernel_handle_t kernel = reinterpret_cast<ze_kernel_handle_t>(javaKernelHandlerPtr);
+    ze_result_t result = zeKernelSetCacheConfig(kernel, flag);
+    LOG_ZE_JNI("zeKernelSetCacheConfig", result);
+    return result;
+}

--- a/levelZeroLib/src/levelZeroKernel.h
+++ b/levelZeroLib/src/levelZeroKernel.h
@@ -55,6 +55,14 @@ JNIEXPORT jint JNICALL Java_uk_ac_manchester_tornado_drivers_spirv_levelzero_Lev
 JNIEXPORT jint JNICALL Java_uk_ac_manchester_tornado_drivers_spirv_levelzero_LevelZeroKernel_zeKernelSetArgumentValue_1nativePtrArg
         (JNIEnv *, jobject, jlong, jint, jint, jlong);
 
+/*
+ * Class:     uk_ac_manchester_tornado_drivers_spirv_levelzero_LevelZeroKernel
+ * Method:    zeKernelSetCacheConfig_native
+ * Signature: (JI)I
+ */
+JNIEXPORT jint JNICALL Java_uk_ac_manchester_tornado_drivers_spirv_levelzero_LevelZeroKernel_zeKernelSetCacheConfig_1native
+        (JNIEnv *, jobject, jlong, jint);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/main/java/uk/ac/manchester/tornado/drivers/spirv/levelzero/LevelZeroKernel.java
+++ b/src/main/java/uk/ac/manchester/tornado/drivers/spirv/levelzero/LevelZeroKernel.java
@@ -62,4 +62,16 @@ public class LevelZeroKernel {
     public int zeKernelSetArgumentValue(long ptrZeKernelHandle, int argIndex, int argSize, long ptrBuffer) {
         return zeKernelSetArgumentValue_nativePtrArg(ptrZeKernelHandle, argIndex, argSize, ptrBuffer);
     }
+
+    private native int zeKernelSetCacheConfig_native(long ptrZeKernelHandle, int zeCacheConfigFlagLargeSlm);
+
+    /**
+     * Sets the preferred cache configuration.
+     *
+     * @param ptrZeKernelHandle
+     * @param flag
+     */
+    public int zeKernelSetCacheConfig(long ptrZeKernelHandle, int flag) {
+        return zeKernelSetCacheConfig_native(ptrZeKernelHandle, flag);
+    }
 }

--- a/src/main/java/uk/ac/manchester/tornado/drivers/spirv/levelzero/ZeCacheConfigFlag.java
+++ b/src/main/java/uk/ac/manchester/tornado/drivers/spirv/levelzero/ZeCacheConfigFlag.java
@@ -1,0 +1,42 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2021, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package uk.ac.manchester.tornado.drivers.spirv.levelzero;
+
+public class ZeCacheConfigFlag {
+
+    /**
+     *  Large SLM size
+     */
+    public static final int ZE_CACHE_CONFIG_FLAG_LARGE_SLM = ZeConstants.ZE_BIT(0);
+
+
+    /**
+     * Large General Data size
+     */
+    public static final int ZE_CACHE_CONFIG_FLAG_LARGE_DATA = ZeConstants.ZE_BIT(1);
+
+    public static final int ZE_CACHE_CONFIG_FLAG_FORCE_UINT32 = 0x7fffffff;
+}

--- a/src/main/java/uk/ac/manchester/tornado/drivers/spirv/levelzero/samples/TestKernelTimer.java
+++ b/src/main/java/uk/ac/manchester/tornado/drivers/spirv/levelzero/samples/TestKernelTimer.java
@@ -38,6 +38,7 @@ import uk.ac.manchester.tornado.drivers.spirv.levelzero.LevelZeroModule;
 import uk.ac.manchester.tornado.drivers.spirv.levelzero.Sizeof;
 import uk.ac.manchester.tornado.drivers.spirv.levelzero.ZeAPIVersion;
 import uk.ac.manchester.tornado.drivers.spirv.levelzero.ZeBuildLogHandle;
+import uk.ac.manchester.tornado.drivers.spirv.levelzero.ZeCacheConfigFlag;
 import uk.ac.manchester.tornado.drivers.spirv.levelzero.ZeCommandListDescription;
 import uk.ac.manchester.tornado.drivers.spirv.levelzero.ZeCommandListHandle;
 import uk.ac.manchester.tornado.drivers.spirv.levelzero.ZeCommandQueueDescription;
@@ -260,6 +261,9 @@ public class TestKernelTimer {
 
         // We create a kernel Object
         LevelZeroKernel levelZeroKernel = new LevelZeroKernel(kernelDesc, kernel, levelZeroModule);
+
+        result = levelZeroKernel.zeKernelSetCacheConfig(kernel.getPtrZeKernelHandle(), ZeCacheConfigFlag.ZE_CACHE_CONFIG_FLAG_LARGE_SLM);
+        LevelZeroUtils.errorLog("zeKernelSetCacheConfig", result);
 
         // Prepare kernel for launch
         // A) Suggest scheduling parameters to level-zero


### PR DESCRIPTION
Function `zeKernelSetCacheConfig` supported: 
https://spec.oneapi.io/level-zero/latest/core/api.html?highlight=zekernelsetcacheconfig#_CPPv422zeKernelSetCacheConfig18ze_kernel_handle_t23ze_cache_config_flags_t 

How to test:

This function is included in the kernel test sample.

```bash
/scripts/kernelTimers.sh
```