### PR TITLE
Shared memory/prefetch

### DIFF
--- a/levelZeroLib/src/levelZeroCommandList.cpp
+++ b/levelZeroLib/src/levelZeroCommandList.cpp
@@ -495,3 +495,24 @@ JNIEXPORT jint JNICALL Java_uk_ac_manchester_tornado_drivers_spirv_levelzero_Lev
     LOG_ZE_JNI("zeCommandListAppendWriteGlobalTimestamp", result);
     return result;
 }
+
+/*
+ * Class:     uk_ac_manchester_tornado_drivers_spirv_levelzero_LevelZeroCommandList
+ * Method:    zeCommandListAppendMemoryPrefetch_native
+ * Signature: (JLuk/ac/manchester/tornado/drivers/spirv/levelzero/LevelZeroBufferInteger;I)I
+ */
+JNIEXPORT jint JNICALL Java_uk_ac_manchester_tornado_drivers_spirv_levelzero_LevelZeroCommandList_zeCommandListAppendMemoryPrefetch_1native
+        (JNIEnv *env, jobject, jlong javaCommandListHandlePtr, jobject levelZeroBufferInteger, jint size) {
+
+    ze_command_list_handle_t commandList = reinterpret_cast<ze_command_list_handle_t>(javaCommandListHandlePtr);
+
+    jclass classLevelZeroIntegerBuffer = env->GetObjectClass(levelZeroBufferInteger);
+    jfieldID fieldBufferPtr = env->GetFieldID(classLevelZeroIntegerBuffer, "ptrBuffer", "J");
+    long bufferPtr = env->GetLongField(levelZeroBufferInteger, fieldBufferPtr);
+    const void *ptr = reinterpret_cast<const void *>(bufferPtr);
+
+    ze_result_t result = zeCommandListAppendMemoryPrefetch(commandList, ptr, size);
+    LOG_ZE_JNI("zeCommandListAppendMemoryPrefetch", result);
+
+    return result;
+}

--- a/levelZeroLib/src/levelZeroCommandList.cpp
+++ b/levelZeroLib/src/levelZeroCommandList.cpp
@@ -516,3 +516,27 @@ JNIEXPORT jint JNICALL Java_uk_ac_manchester_tornado_drivers_spirv_levelzero_Lev
 
     return result;
 }
+
+/*
+ * Class:     uk_ac_manchester_tornado_drivers_spirv_levelzero_LevelZeroCommandList
+ * Method:    zeCommandListAppendMemAdvise_native
+ * Signature: (JJLuk/ac/manchester/tornado/drivers/spirv/levelzero/LevelZeroBufferInteger;II)I
+ */
+JNIEXPORT jint JNICALL Java_uk_ac_manchester_tornado_drivers_spirv_levelzero_LevelZeroCommandList_zeCommandListAppendMemAdvise_1native
+        (JNIEnv *env, jobject object, jlong javaCommandListHandlePtr, jlong javaDeviceHandlePtr, jobject levelZeroBufferInteger, jint size, jint advice) {
+
+    ze_command_list_handle_t commandList = reinterpret_cast<ze_command_list_handle_t>(javaCommandListHandlePtr);
+    ze_device_handle_t deviceHandle = reinterpret_cast<ze_device_handle_t>(javaDeviceHandlePtr);
+
+    ze_memory_advice_t memoryAdvice = static_cast<ze_memory_advice_t>(advice);
+
+    jclass classLevelZeroIntegerBuffer = env->GetObjectClass(levelZeroBufferInteger);
+    jfieldID fieldBufferPtr = env->GetFieldID(classLevelZeroIntegerBuffer, "ptrBuffer", "J");
+    long bufferPtr = env->GetLongField(levelZeroBufferInteger, fieldBufferPtr);
+    const void *ptr = reinterpret_cast<const void *>(bufferPtr);
+
+    ze_result_t result = zeCommandListAppendMemAdvise(commandList, deviceHandle, ptr, size, memoryAdvice);
+    LOG_ZE_JNI("zeCommandListAppendMemAdvise", result);
+
+    return result;
+}

--- a/levelZeroLib/src/levelZeroCommandList.h
+++ b/levelZeroLib/src/levelZeroCommandList.h
@@ -209,6 +209,14 @@ JNIEXPORT jint JNICALL Java_uk_ac_manchester_tornado_drivers_spirv_levelzero_Lev
 JNIEXPORT jint JNICALL Java_uk_ac_manchester_tornado_drivers_spirv_levelzero_LevelZeroCommandList_zeCommandListAppendMemoryPrefetch_1native
         (JNIEnv *, jobject, jlong, jobject, jint);
 
+/*
+ * Class:     uk_ac_manchester_tornado_drivers_spirv_levelzero_LevelZeroCommandList
+ * Method:    zeCommandListAppendMemAdvise_native
+ * Signature: (JJLuk/ac/manchester/tornado/drivers/spirv/levelzero/LevelZeroBufferInteger;II)I
+ */
+JNIEXPORT jint JNICALL Java_uk_ac_manchester_tornado_drivers_spirv_levelzero_LevelZeroCommandList_zeCommandListAppendMemAdvise_1native
+        (JNIEnv *, jobject, jlong, jlong, jobject, jint, jint);
+
 #ifdef __cplusplus
 }
 #endif

--- a/levelZeroLib/src/levelZeroCommandList.h
+++ b/levelZeroLib/src/levelZeroCommandList.h
@@ -201,6 +201,14 @@ JNIEXPORT jint JNICALL Java_uk_ac_manchester_tornado_drivers_spirv_levelzero_Lev
 JNIEXPORT jint JNICALL Java_uk_ac_manchester_tornado_drivers_spirv_levelzero_LevelZeroCommandList_zeCommandListAppendWriteGlobalTimestamp_1native
     (JNIEnv *, jobject, jlong, jobject, jobject, jint, jobject);
 
+/*
+ * Class:     uk_ac_manchester_tornado_drivers_spirv_levelzero_LevelZeroCommandList
+ * Method:    zeCommandListAppendMemoryPrefetch_native
+ * Signature: (JLuk/ac/manchester/tornado/drivers/spirv/levelzero/LevelZeroBufferInteger;I)I
+ */
+JNIEXPORT jint JNICALL Java_uk_ac_manchester_tornado_drivers_spirv_levelzero_LevelZeroCommandList_zeCommandListAppendMemoryPrefetch_1native
+        (JNIEnv *, jobject, jlong, jobject, jint);
+
 #ifdef __cplusplus
 }
 #endif

--- a/levelZeroLib/src/levelZeroKernel.cpp
+++ b/levelZeroLib/src/levelZeroKernel.cpp
@@ -83,3 +83,16 @@ JNIEXPORT jint JNICALL Java_uk_ac_manchester_tornado_drivers_spirv_levelzero_Lev
     LOG_ZE_JNI("zeKernelSetArgumentValue [PTR]", result);
     return result;
 }
+
+/*
+ * Class:     uk_ac_manchester_tornado_drivers_spirv_levelzero_LevelZeroKernel
+ * Method:    zeKernelSetCacheConfig_native
+ * Signature: (JI)I
+ */
+JNIEXPORT jint JNICALL Java_uk_ac_manchester_tornado_drivers_spirv_levelzero_LevelZeroKernel_zeKernelSetCacheConfig_1native
+    (JNIEnv *, jobject, jlong javaKernelHandlerPtr, jint flag) {
+    ze_kernel_handle_t kernel = reinterpret_cast<ze_kernel_handle_t>(javaKernelHandlerPtr);
+    ze_result_t result = zeKernelSetCacheConfig(kernel, flag);
+    LOG_ZE_JNI("zeKernelSetCacheConfig", result);
+    return result;
+}

--- a/levelZeroLib/src/levelZeroKernel.h
+++ b/levelZeroLib/src/levelZeroKernel.h
@@ -55,6 +55,14 @@ JNIEXPORT jint JNICALL Java_uk_ac_manchester_tornado_drivers_spirv_levelzero_Lev
 JNIEXPORT jint JNICALL Java_uk_ac_manchester_tornado_drivers_spirv_levelzero_LevelZeroKernel_zeKernelSetArgumentValue_1nativePtrArg
         (JNIEnv *, jobject, jlong, jint, jint, jlong);
 
+/*
+ * Class:     uk_ac_manchester_tornado_drivers_spirv_levelzero_LevelZeroKernel
+ * Method:    zeKernelSetCacheConfig_native
+ * Signature: (JI)I
+ */
+JNIEXPORT jint JNICALL Java_uk_ac_manchester_tornado_drivers_spirv_levelzero_LevelZeroKernel_zeKernelSetCacheConfig_1native
+        (JNIEnv *, jobject, jlong, jint);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/main/java/uk/ac/manchester/tornado/drivers/spirv/levelzero/LevelZeroCommandList.java
+++ b/src/main/java/uk/ac/manchester/tornado/drivers/spirv/levelzero/LevelZeroCommandList.java
@@ -423,7 +423,7 @@ public class LevelZeroCommandList {
 
     /**
      * Reset a command list to initial (empty) state; ready for appending commands.
-     * 
+     *
      * <ul>
      * <li>The application must ensure the device is not currently referencing the
      * command list before it is reset</li>
@@ -431,11 +431,11 @@ public class LevelZeroCommandList {
      * with the same command list handle.</li>
      * <li>The implementation of this function should be lock-free.</li>
      * </ul>
-     * 
+     *
      * @param commandListHandlerPtr
      *            [in] handle of command list object to reset
      * @return
-     * 
+     *
      *         ZE_RESULT_SUCCESS
      *
      *         ZE_RESULT_ERROR_UNINITIALIZED
@@ -462,7 +462,7 @@ public class LevelZeroCommandList {
     /**
      * Appends a memory write of the device's global timestamp value into a command
      * list.
-     * 
+     *
      * @param commandListHandlerPtr
      *            Pointer to the command list handler
      * @param bufferTimeStamp
@@ -475,7 +475,7 @@ public class LevelZeroCommandList {
      * @param phWaitEvents
      *            handle of the events to wait on before executing query
      * @return Error code
-     * 
+     *
      *         <code>
      *  - ZE_RESULT_SUCCESS
      *  - ZE_RESULT_ERROR_UNINITIALIZED
@@ -488,9 +488,15 @@ public class LevelZeroCommandList {
      *  - ZE_RESULT_ERROR_INVALID_SIZE
      *   + `(null == phWaitEvents) && (0 < numWaitEvents)`
      *      </code>
-     * 
+     *
      */
     public int zeCommandListAppendWriteGlobalTimestamp(long commandListHandlerPtr, LevelZeroByteBuffer bufferTimeStamp, ZeEventHandle hSignalEvents, int numWaitEvents, ZeEventHandle phWaitEvents) {
         return zeCommandListAppendWriteGlobalTimestamp_native(commandListHandlerPtr, bufferTimeStamp, hSignalEvents, numWaitEvents, phWaitEvents);
+    }
+
+    private native int zeCommandListAppendMemoryPrefetch_native(long commandListHandlerPtr, LevelZeroBufferInteger bufferA, int bufferSize);
+
+    public int zeCommandListAppendMemoryPrefetch(long commandListHandlerPtr, LevelZeroBufferInteger bufferA, int bufferSize) {
+        return zeCommandListAppendMemoryPrefetch_native(commandListHandlerPtr, bufferA, bufferSize);
     }
 }

--- a/src/main/java/uk/ac/manchester/tornado/drivers/spirv/levelzero/LevelZeroCommandList.java
+++ b/src/main/java/uk/ac/manchester/tornado/drivers/spirv/levelzero/LevelZeroCommandList.java
@@ -496,6 +496,17 @@ public class LevelZeroCommandList {
 
     private native int zeCommandListAppendMemoryPrefetch_native(long commandListHandlerPtr, LevelZeroBufferInteger bufferA, int bufferSize);
 
+    /**
+     * Asynchronously prefetches shared memory to the device associated with the specified command list.
+     *
+     * @param commandListHandlerPtr
+     *         Pointer Handler to the command list
+     * @param bufferA
+     *         LevelZeroBufferInteger - pointer to start of the memory range to prefetch.
+     * @param bufferSize
+     *        Size in bytes of the memory range to prefetch.
+     * @return
+     */
     public int zeCommandListAppendMemoryPrefetch(long commandListHandlerPtr, LevelZeroBufferInteger bufferA, int bufferSize) {
         return zeCommandListAppendMemoryPrefetch_native(commandListHandlerPtr, bufferA, bufferSize);
     }

--- a/src/main/java/uk/ac/manchester/tornado/drivers/spirv/levelzero/LevelZeroCommandList.java
+++ b/src/main/java/uk/ac/manchester/tornado/drivers/spirv/levelzero/LevelZeroCommandList.java
@@ -510,4 +510,10 @@ public class LevelZeroCommandList {
     public int zeCommandListAppendMemoryPrefetch(long commandListHandlerPtr, LevelZeroBufferInteger bufferA, int bufferSize) {
         return zeCommandListAppendMemoryPrefetch_native(commandListHandlerPtr, bufferA, bufferSize);
     }
+
+    private native int zeCommandListAppendMemAdvise_native(long commandListHandlerPtr, long deviceHandlerPtr, LevelZeroBufferInteger bufferA, int bufferSize, int memoryAdvice);
+
+    public int zeCommandListAppendMemAdvise(long commandListHandlerPtr, long deviceHandlerPtr, LevelZeroBufferInteger bufferA, int bufferSize, int memoryAdvice) {
+        return zeCommandListAppendMemAdvise_native(commandListHandlerPtr, deviceHandlerPtr, bufferA, bufferSize, memoryAdvice);
+    }
 }

--- a/src/main/java/uk/ac/manchester/tornado/drivers/spirv/levelzero/LevelZeroKernel.java
+++ b/src/main/java/uk/ac/manchester/tornado/drivers/spirv/levelzero/LevelZeroKernel.java
@@ -62,4 +62,16 @@ public class LevelZeroKernel {
     public int zeKernelSetArgumentValue(long ptrZeKernelHandle, int argIndex, int argSize, long ptrBuffer) {
         return zeKernelSetArgumentValue_nativePtrArg(ptrZeKernelHandle, argIndex, argSize, ptrBuffer);
     }
+
+    private native int zeKernelSetCacheConfig_native(long ptrZeKernelHandle, int zeCacheConfigFlagLargeSlm);
+
+    /**
+     * Sets the preferred cache configuration.
+     *
+     * @param ptrZeKernelHandle
+     * @param flag
+     */
+    public int zeKernelSetCacheConfig(long ptrZeKernelHandle, int flag) {
+        return zeKernelSetCacheConfig_native(ptrZeKernelHandle, flag);
+    }
 }

--- a/src/main/java/uk/ac/manchester/tornado/drivers/spirv/levelzero/ZeCacheConfigFlag.java
+++ b/src/main/java/uk/ac/manchester/tornado/drivers/spirv/levelzero/ZeCacheConfigFlag.java
@@ -1,0 +1,42 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2021, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package uk.ac.manchester.tornado.drivers.spirv.levelzero;
+
+public class ZeCacheConfigFlag {
+
+    /**
+     *  Large SLM size
+     */
+    public static final int ZE_CACHE_CONFIG_FLAG_LARGE_SLM = ZeConstants.ZE_BIT(0);
+
+
+    /**
+     * Large General Data size
+     */
+    public static final int ZE_CACHE_CONFIG_FLAG_LARGE_DATA = ZeConstants.ZE_BIT(1);
+
+    public static final int ZE_CACHE_CONFIG_FLAG_FORCE_UINT32 = 0x7fffffff;
+}

--- a/src/main/java/uk/ac/manchester/tornado/drivers/spirv/levelzero/ZeMemoryAdvice.java
+++ b/src/main/java/uk/ac/manchester/tornado/drivers/spirv/levelzero/ZeMemoryAdvice.java
@@ -1,0 +1,74 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2021, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package uk.ac.manchester.tornado.drivers.spirv.levelzero;
+
+/**
+ * Supported memory advice hints.
+ */
+public class ZeMemoryAdvice {
+
+    /**
+     * Hint that memory will be read from frequently and written to rarely
+     */
+    public static final int ZE_MEMORY_ADVICE_SET_READ_MOSTLY = 0;
+
+    /**
+     * Removes the affect of {@link ZeMemoryAdvice.ZE_MEMORY_ADVICE_SET_READ_MOSTLY}
+     */
+    public static final int ZE_MEMORY_ADVICE_CLEAR_READ_MOSTLY = 1;
+
+    /**
+     * Hint that the preferred memory location is the specified device
+     */
+    public static final int ZE_MEMORY_ADVICE_SET_PREFERRED_LOCATION = 2;
+
+    /**
+     * Removes the affect of {@link ZeMemoryAdvice.ZE_MEMORY_ADVICE_SET_PREFERRED_LOCATION}
+     */
+    public static final int ZE_MEMORY_ADVICE_CLEAR_PREFERRED_LOCATION = 3;
+
+    /**
+     * Hints that memory will mostly be accessed non-atomically
+     */
+    public static final int ZE_MEMORY_ADVICE_SET_NON_ATOMIC_MOSTLY = 4;
+
+    /**
+     * Removes the affect of {@link ZeMemoryAdvice.ZE_MEMORY_ADVICE_SET_NON_ATOMIC_MOSTLY}
+     */
+    public static final int ZE_MEMORY_ADVICE_CLEAR_NON_ATOMIC_MOSTLY = 5;
+
+    /**
+     * Hints that memory should be cached
+     */
+    public static final int ZE_MEMORY_ADVICE_BIAS_CACHED = 6;
+
+    /**
+     * Hints that memory should be not be cached
+     */
+    public static final int ZE_MEMORY_ADVICE_BIAS_UNCACHED = 7;
+
+    public static final int ZE_MEMORY_ADVICE_FORCE_UINT32 = 0x7fffffff;
+}

--- a/src/main/java/uk/ac/manchester/tornado/drivers/spirv/levelzero/samples/TestKernelTimer.java
+++ b/src/main/java/uk/ac/manchester/tornado/drivers/spirv/levelzero/samples/TestKernelTimer.java
@@ -64,6 +64,7 @@ import uk.ac.manchester.tornado.drivers.spirv.levelzero.ZeInitFlag;
 import uk.ac.manchester.tornado.drivers.spirv.levelzero.ZeKernelDesc;
 import uk.ac.manchester.tornado.drivers.spirv.levelzero.ZeKernelHandle;
 import uk.ac.manchester.tornado.drivers.spirv.levelzero.ZeKernelTimeStampResult;
+import uk.ac.manchester.tornado.drivers.spirv.levelzero.ZeMemoryAdvice;
 import uk.ac.manchester.tornado.drivers.spirv.levelzero.ZeModuleDesc;
 import uk.ac.manchester.tornado.drivers.spirv.levelzero.ZeModuleFormat;
 import uk.ac.manchester.tornado.drivers.spirv.levelzero.ZeModuleHandle;
@@ -222,6 +223,9 @@ public class TestKernelTimer {
         LevelZeroUtils.errorLog("zeMemAllocShared", result);
 
         result = commandList.zeCommandListAppendMemoryPrefetch(commandList.getCommandListHandlerPtr(), bufferA, bufferSize);
+        LevelZeroUtils.errorLog("zeCommandListAppendMemoryPrefetch", result);
+
+        result = commandList.zeCommandListAppendMemAdvise(commandList.getCommandListHandlerPtr(), device.getDeviceHandlerPtr(), bufferA, bufferSize, ZeMemoryAdvice.ZE_MEMORY_ADVICE_SET_PREFERRED_LOCATION);
         LevelZeroUtils.errorLog("zeCommandListAppendMemoryPrefetch", result);
 
         bufferA.memset(100, elements);

--- a/src/main/java/uk/ac/manchester/tornado/drivers/spirv/levelzero/samples/TestKernelTimer.java
+++ b/src/main/java/uk/ac/manchester/tornado/drivers/spirv/levelzero/samples/TestKernelTimer.java
@@ -221,6 +221,9 @@ public class TestKernelTimer {
         result = context.zeMemAllocShared(context.getDefaultContextPtr(), deviceMemAllocDesc, hostMemAllocDesc, bufferSize, 1, device.getDeviceHandlerPtr(), bufferB);
         LevelZeroUtils.errorLog("zeMemAllocShared", result);
 
+        result = commandList.zeCommandListAppendMemoryPrefetch(commandList.getCommandListHandlerPtr(), bufferA, bufferSize);
+        LevelZeroUtils.errorLog("zeCommandListAppendMemoryPrefetch", result);
+
         bufferA.memset(100, elements);
         bufferB.memset(0, elements);
 

--- a/src/main/java/uk/ac/manchester/tornado/drivers/spirv/levelzero/samples/TestKernelTimer.java
+++ b/src/main/java/uk/ac/manchester/tornado/drivers/spirv/levelzero/samples/TestKernelTimer.java
@@ -38,6 +38,7 @@ import uk.ac.manchester.tornado.drivers.spirv.levelzero.LevelZeroModule;
 import uk.ac.manchester.tornado.drivers.spirv.levelzero.Sizeof;
 import uk.ac.manchester.tornado.drivers.spirv.levelzero.ZeAPIVersion;
 import uk.ac.manchester.tornado.drivers.spirv.levelzero.ZeBuildLogHandle;
+import uk.ac.manchester.tornado.drivers.spirv.levelzero.ZeCacheConfigFlag;
 import uk.ac.manchester.tornado.drivers.spirv.levelzero.ZeCommandListDescription;
 import uk.ac.manchester.tornado.drivers.spirv.levelzero.ZeCommandListHandle;
 import uk.ac.manchester.tornado.drivers.spirv.levelzero.ZeCommandQueueDescription;
@@ -260,6 +261,9 @@ public class TestKernelTimer {
 
         // We create a kernel Object
         LevelZeroKernel levelZeroKernel = new LevelZeroKernel(kernelDesc, kernel, levelZeroModule);
+
+        result = levelZeroKernel.zeKernelSetCacheConfig(kernel.getPtrZeKernelHandle(), ZeCacheConfigFlag.ZE_CACHE_CONFIG_FLAG_LARGE_SLM);
+        LevelZeroUtils.errorLog("zeKernelSetCacheConfig", result);
 
         // Prepare kernel for launch
         // A) Suggest scheduling parameters to level-zero


### PR DESCRIPTION
Native Functions:  
 - `zeCommandListAppendMemAdvise` : https://spec.oneapi.io/level-zero/latest/core/api.html?highlight=zecommandlistappendmemoryprefetch#zecommandlistappendmemoryprefetch
 - `zeCommandListAppendMemoryPrefetch`  :  https://spec.oneapi.io/level-zero/latest/core/api.html?highlight=zecommandlistappendmemoryprefetch#zecommandlistappendmemadvise 

for Integer level zero buffers added.  Integer version for PoC and performance metrics for TornadoVM. 
